### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/factory.js
+++ b/lib/factory.js
@@ -4,7 +4,7 @@ var util = require('util');
 var request = require('request');
 var Promise = require('bluebird');
 var jwt = require('jsonwebtoken');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var backoff = require('backoff');
 var chalk = require('chalk');
 

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "lodash": "^3.10.1",
     "mime": "^1.3.4",
     "moment": "^2.10.6",
-    "node-uuid": "^1.4.3",
-    "request": "^2.61.0"
+    "request": "^2.61.0",
+    "uuid": "^3.0.0"
   },
   "directories": {
     "test": "test"

--- a/test/spec/trash.js
+++ b/test/spec/trash.js
@@ -2,7 +2,7 @@
 
 var util = require('util');
 var _ = require('lodash');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 module.exports = function(test, Promise) {
 


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.